### PR TITLE
Update NLORivetAnalysis.cc

### DIFF
--- a/Analysis/NLORivetAnalysis.cc
+++ b/Analysis/NLORivetAnalysis.cc
@@ -122,10 +122,10 @@ void NLORivetAnalysis::analyze(ThePEG::tEventPtr event, long ieve, int loop, int
   CurrentGenerator::Redirect stdout(cout);
   if(_rivet){
 #if ThePEG_RIVET_VERSION == 1
-    _rivet->analyze(*hepmc);
+    _rivet->analyze(const_cast<const HepMC::GenEvent&>(*hepmc));
 #elif ThePEG_RIVET_VERSION > 1
     try {
-      _rivet->analyze(*hepmc);
+      _rivet->analyze(const_cast<const HepMC::GenEvent&>(*hepmc));
     } catch (const YODA::Exception & e) {
       Throw<Exception>() << "Warning: Rivet/Yoda got the exception: "<< e.what()<<"\n"
                          << Exception::warning;
@@ -146,10 +146,10 @@ void NLORivetAnalysis::analyze(ThePEG::tEventPtr event, long ieve, int loop, int
 
       if ( _rivet ){
 #if ThePEG_RIVET_VERSION == 1
-        _rivet->analyze(*hepmc);
+        _rivet->analyze(const_cast<const HepMC::GenEvent&>(*hepmc));
 #elif ThePEG_RIVET_VERSION > 1
         try {
-          _rivet->analyze(*hepmc);
+          _rivet->analyze(const_cast<const HepMC::GenEvent&>(*hepmc));
         } catch (const YODA::Exception & e) {
           Throw<Exception>() << "Warning: Rivet/Yoda got the exception: "<< e.what()<<"\n"
                              << Exception::warning;


### PR DESCRIPTION
Const cast dereference of HepMC::GenEvent pointer to match Rivet::AnalysisHander::analyze call - hack for older compilers